### PR TITLE
Update getDocumentTimestampByIndex guard

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -73,7 +73,8 @@ export function getDocumentTimestampByIndex(
   index: number,
 ) {
   if (!documents) return new Date();
-  if (index > documents.length) return new Date();
+  // Guard against invalid indexes that would throw an error
+  if (index >= documents.length) return new Date();
 
   return documents[index].createdAt;
 }


### PR DESCRIPTION
## Summary
- fix bounds check in `getDocumentTimestampByIndex`
- clarify comment for invalid index

## Testing
- `pnpm lint`
- `pnpm test` *(fails: [setup:auth] authenticate, /api/chat and /api/document tests)*

------
https://chatgpt.com/codex/tasks/task_e_683f61dff5b883318f10e4f9cbfa45b6